### PR TITLE
[#17] 이미지 편집 라이브러리 변경 및 사용성 최적화

### DIFF
--- a/Codive/Features/Add/Domain/UseCases/FetchPhotosUseCase.swift
+++ b/Codive/Features/Add/Domain/UseCases/FetchPhotosUseCase.swift
@@ -31,23 +31,27 @@ final class FetchPhotosUseCase {
         return repository.fetchAlbums()
     }
     
-    /// 앨범 목록과 기본으로 선택할 앨범을 함께 반환
+    /// 앨범 목록과 기본으로 선택할 앨범을 함께 반환 (비동기)
     /// 비즈니스 규칙: 최근 항목이 있으면 최근 항목, 없으면 첫 번째 앨범
-    func fetchAlbumsWithDefault() -> (albums: [PhotoAlbum], defaultAlbum: PhotoAlbum?) {
-        let albums = repository.fetchAlbums()
-        
-        // 최근 항목 찾기
-        let defaultAlbum = albums.first {
-            $0.collection.assetCollectionSubtype == .smartAlbumUserLibrary
-        } ?? albums.first
-        
-        return (albums, defaultAlbum)
+    func fetchAlbumsWithDefault() async -> (albums: [PhotoAlbum], defaultAlbum: PhotoAlbum?) {
+        return await Task.detached(priority: .userInitiated) {
+            let albums = self.repository.fetchAlbums()
+            
+            // 최근 항목 찾기
+            let defaultAlbum = albums.first {
+                $0.collection.assetCollectionSubtype == .smartAlbumUserLibrary
+            } ?? albums.first
+            
+            return (albums, defaultAlbum)
+        }.value
     }
-    
+
     // MARK: - Fetch Photos
     
-    func fetchPhotos(from album: PhotoAlbum) -> [PhotoAsset] {
-        return repository.fetchPhotos(from: album)
+    func fetchPhotos(from album: PhotoAlbum) async -> [PhotoAsset] {
+        return await Task.detached(priority: .userInitiated) {
+            self.repository.fetchPhotos(from: album)
+        }.value
     }
     
     /// 여러 앨범에서 최근 사진들을 합쳐서 가져오기

--- a/Codive/Features/Add/Presentation/Components/RecordAddView/AlbumBottomSheet.swift
+++ b/Codive/Features/Add/Presentation/Components/RecordAddView/AlbumBottomSheet.swift
@@ -15,7 +15,7 @@ struct AlbumBottomSheet: View {
     let albums: [PhotoAlbum]
     let selectedAlbum: PhotoAlbum?
     let viewModel: RecordAddViewModel
-    let onSelect: (PhotoAlbum) -> Void
+    let onSelect: (PhotoAlbum) async -> Void
     
     // MARK: - Body
     var body: some View {
@@ -35,7 +35,7 @@ struct AlbumBottomSheet: View {
                             isSelected: selectedAlbum?.id == album.id,
                             viewModel: viewModel
                         ) {
-                            onSelect(album)
+                            await onSelect(album)
                         }
                     }
                 }
@@ -52,17 +52,18 @@ struct AlbumRow: View {
     let album: PhotoAlbum
     let isSelected: Bool
     let viewModel: RecordAddViewModel
-    let onTap: () -> Void
+    let onTap: () async -> Void
     
     @State private var thumbnail: UIImage?
     
     // MARK: - Body
     var body: some View {
         Button {
-            onTap()
+            Task {
+                await onTap()
+            }
         } label: {
             HStack(spacing: 12) {
-                // 썸네일
                 if let thumbnail = thumbnail {
                     Image(uiImage: thumbnail)
                         .resizable()

--- a/Codive/Features/Add/Presentation/Components/RecordAddView/SkeletonCell.swift
+++ b/Codive/Features/Add/Presentation/Components/RecordAddView/SkeletonCell.swift
@@ -1,0 +1,44 @@
+//
+//  SkeletonCell.swift
+//  Codive
+//
+//  Created by 황상환 on 11/3/25.
+//
+
+import SwiftUI
+
+// MARK: - SkeletonCell
+struct SkeletonCell: View {
+    
+    // MARK: - Properties
+    let size: CGSize
+    @State private var isAnimating = false
+    
+    // MARK: - Body
+    var body: some View {
+        Rectangle()
+            .fill(Color.Codive.grayscale6)
+            .frame(width: size.width, height: size.height)
+            .overlay(
+                Rectangle()
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                Color.Codive.grayscale6.opacity(0.3),
+                                Color.white.opacity(0.5),
+                                Color.Codive.grayscale6.opacity(0.3)
+                            ],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .offset(x: isAnimating ? size.width * 2 : -size.width * 2)
+            )
+            .clipShape(Rectangle())
+            .onAppear {
+                withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
+                    isAnimating = true
+                }
+            }
+    }
+}

--- a/Codive/Features/Add/Presentation/View/ImageCropView.swift
+++ b/Codive/Features/Add/Presentation/View/ImageCropView.swift
@@ -10,31 +10,33 @@ import SwiftyCrop
 
 struct ImageCropView: View {
     
+    // MARK: - Properties
     let image: UIImage
     let onComplete: (UIImage) -> Void
     let onCancel: () -> Void
     
+    // MARK: - Body
     var body: some View {
-        GeometryReader { geometry in
-            let screenWidth = geometry.size.width
-            let maskHeight = (screenWidth - 40) * (4/3) 
-            let maskRadius = maskHeight / 2
-            
-            SwiftyCropView(
-                imageToCrop: image,
-                maskShape: .rectangle,
-                configuration: SwiftyCropConfiguration(
-                    maxMagnificationScale: 30.0,
-                    maskRadius: maskRadius,
-                    cropImageCircular: false,
-                    rotateImage: false,
-                    zoomSensitivity: 5.0,
-                    rectAspectRatio: 3/4
-                )
-            ) { croppedImage in
-                if let croppedImage = croppedImage {
-                    onComplete(croppedImage)
-                }
+        let screenWidth = UIScreen.main.bounds.width
+        let maskHeight = (screenWidth - 40) * (4/3)
+        let maskRadius = maskHeight / 2
+        
+        SwiftyCropView(
+            imageToCrop: image,
+            maskShape: .rectangle,
+            configuration: SwiftyCropConfiguration(
+                maxMagnificationScale: 30.0,
+                maskRadius: maskRadius,
+                cropImageCircular: false,
+                rotateImage: false,
+                zoomSensitivity: 0.5,
+                rectAspectRatio: 3/4
+            )
+        ) { croppedImage in
+            if let croppedImage = croppedImage {
+                onComplete(croppedImage)
+            } else {
+                onCancel()
             }
         }
     }

--- a/Codive/Features/Add/Presentation/View/ImageCropView.swift
+++ b/Codive/Features/Add/Presentation/View/ImageCropView.swift
@@ -6,58 +6,36 @@
 //
 
 import SwiftUI
-import Mantis
+import SwiftyCrop
 
-// MARK: - ImageCropView
-struct ImageCropView: UIViewControllerRepresentable {
+struct ImageCropView: View {
     
     let image: UIImage
     let onComplete: (UIImage) -> Void
     let onCancel: () -> Void
     
-    func makeUIViewController(context: Context) -> CropViewController {
-        // 3:4 비율 설정
-        var config = Mantis.Config()
-        config.presetFixedRatioType = .alwaysUsingOnePresetFixedRatio(ratio: 3.0 / 4.0)
-        config.cropViewConfig.cropShapeType = .rect
-        
-        let cropViewController = Mantis.cropViewController(
-            image: image,
-            config: config
-        )
-        cropViewController.delegate = context.coordinator
-        
-        return cropViewController
-    }
-    
-    func updateUIViewController(_ uiViewController: CropViewController, context: Context) {}
-    
-    func makeCoordinator() -> Coordinator {
-        Coordinator(self)
-    }
-    
-    // MARK: - Coordinator
-    class Coordinator: NSObject, CropViewControllerDelegate {
-        let parent: ImageCropView
-        
-        init(_ parent: ImageCropView) {
-            self.parent = parent
-        }
-        
-        func cropViewControllerDidCrop(
-            _ cropViewController: CropViewController,
-            cropped: UIImage,
-            transformation: Transformation,
-            cropInfo: CropInfo
-        ) {
-            parent.onComplete(cropped)
-        }
-        
-        func cropViewControllerDidCancel(
-            _ cropViewController: CropViewController,
-            original: UIImage
-        ) {
-            parent.onCancel()
+    var body: some View {
+        GeometryReader { geometry in
+            let screenWidth = geometry.size.width
+            let maskHeight = (screenWidth - 40) * (4/3) 
+            let maskRadius = maskHeight / 2
+            
+            SwiftyCropView(
+                imageToCrop: image,
+                maskShape: .rectangle,
+                configuration: SwiftyCropConfiguration(
+                    maxMagnificationScale: 30.0,
+                    maskRadius: maskRadius,
+                    cropImageCircular: false,
+                    rotateImage: false,
+                    zoomSensitivity: 5.0,
+                    rectAspectRatio: 3/4
+                )
+            ) { croppedImage in
+                if let croppedImage = croppedImage {
+                    onComplete(croppedImage)
+                }
+            }
         }
     }
 }

--- a/Codive/Features/Add/Presentation/View/ImageCropView.swift
+++ b/Codive/Features/Add/Presentation/View/ImageCropView.swift
@@ -19,14 +19,13 @@ struct ImageCropView: View {
     var body: some View {
         let screenWidth = UIScreen.main.bounds.width
         let maskHeight = (screenWidth - 40) * (4/3)
-        let maskRadius = maskHeight / 2
         
         SwiftyCropView(
             imageToCrop: image,
             maskShape: .rectangle,
             configuration: SwiftyCropConfiguration(
                 maxMagnificationScale: 30.0,
-                maskRadius: maskRadius,
+                maskRadius: maskHeight / 2,
                 cropImageCircular: false,
                 rotateImage: false,
                 zoomSensitivity: 5.0,

--- a/Codive/Features/Add/Presentation/View/ImageCropView.swift
+++ b/Codive/Features/Add/Presentation/View/ImageCropView.swift
@@ -29,7 +29,7 @@ struct ImageCropView: View {
                 maskRadius: maskRadius,
                 cropImageCircular: false,
                 rotateImage: false,
-                zoomSensitivity: 0.5,
+                zoomSensitivity: 5.0,
                 rectAspectRatio: 3/4
             )
         ) { croppedImage in

--- a/Codive/Features/Add/Presentation/View/PhotoEditView.swift
+++ b/Codive/Features/Add/Presentation/View/PhotoEditView.swift
@@ -32,15 +32,14 @@ struct PhotoEditView: View {
             // Photo Thumbnails (상단 미리보기)
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 12) {
-                    ForEach(viewModel.selectedPhotos) { photo in
+                    ForEach(Array(viewModel.selectedPhotos.enumerated()), id: \.element.id) { index, photo in
                         PhotoEditCell(
-                            photo: photo,
-                            isSelected: photo.id == viewModel.currentPhoto?.id
+                            photo: viewModel.selectedPhotos[index],
+                            isSelected: index == viewModel.currentIndex
                         )
+                        .id("\(photo.id)-\(photo.croppedImage.hashValue)")
                         .onTapGesture {
-                            if let index = viewModel.selectedPhotos.firstIndex(where: { $0.id == photo.id }) {
-                                viewModel.currentIndex = index
-                            }
+                            viewModel.currentIndex = index
                         }
                         .onDrag {
                             self.draggedPhoto = photo

--- a/Codive/Features/Add/Presentation/View/PhotoEditView.swift
+++ b/Codive/Features/Add/Presentation/View/PhotoEditView.swift
@@ -111,15 +111,17 @@ struct PhotoEditView: View {
         .background(Color.white)
         .sheet(isPresented: $viewModel.isEditingMode) {
             if let currentPhoto = viewModel.currentPhoto {
-                ImageCropView(
-                    image: currentPhoto.originalImage,
-                    onComplete: { croppedImage in
-                        viewModel.updateCroppedImage(croppedImage)
-                    },
-                    onCancel: {
-                        viewModel.cancelEditing()
-                    }
-                )
+                NavigationView {
+                    ImageCropView(
+                        image: currentPhoto.originalImage,
+                        onComplete: { croppedImage in
+                            viewModel.updateCroppedImage(croppedImage)
+                        },
+                        onCancel: {
+                            viewModel.cancelEditing()
+                        }
+                    )
+                }
             }
         }
     }

--- a/Codive/Features/Add/Presentation/View/PhotoEditView.swift
+++ b/Codive/Features/Add/Presentation/View/PhotoEditView.swift
@@ -111,17 +111,16 @@ struct PhotoEditView: View {
         .background(Color.white)
         .sheet(isPresented: $viewModel.isEditingMode) {
             if let currentPhoto = viewModel.currentPhoto {
-                NavigationView {
-                    ImageCropView(
-                        image: currentPhoto.originalImage,
-                        onComplete: { croppedImage in
-                            viewModel.updateCroppedImage(croppedImage)
-                        },
-                        onCancel: {
-                            viewModel.cancelEditing()
-                        }
-                    )
-                }
+                ImageCropView(
+                    image: currentPhoto.originalImage,
+                    onComplete: { croppedImage in
+                        viewModel.updateCroppedImage(croppedImage)
+                        viewModel.isEditingMode = false
+                    },
+                    onCancel: {
+                        viewModel.isEditingMode = false
+                    }
+                )
             }
         }
     }

--- a/Codive/Features/Add/Presentation/View/RecordAddView.swift
+++ b/Codive/Features/Add/Presentation/View/RecordAddView.swift
@@ -23,70 +23,76 @@ struct RecordAddView: View {
     
     // MARK: - Body
     var body: some View {
-        VStack(spacing: 0) {
-            // Navigation Bar
-            CustomNavigationBar(
-                title: TextLiteral.Add.recordTitle,
-                onBack: {
-                    viewModel.dismissView()
-                },
-                rightButton: .text(
-                    title: TextLiteral.Common.complete,
-                    isEnabled: viewModel.isCompleteEnabled
-                ) {
-                    viewModel.completeSelection()
-                }
-            )
-            
-            // Album Selector
-            Button {
-                viewModel.showAlbumSheet()
-            } label: {
-                HStack(spacing: 4) {
-                    Text(viewModel.selectedAlbumTitle)
-                        .font(.codive_body1_medium)
-                        .foregroundStyle(Color.Codive.grayscale1)
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 14))
-                        .foregroundStyle(Color.Codive.grayscale3)
-                }
-                .padding(.horizontal, 20)
-                .padding(.vertical, 16)
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            
-            // Photo Grid
-            ScrollView {
-                LazyVGrid(columns: columns, spacing: 3) {
-                    // 첫 번째 셀: 카메라
-                    CameraCell(
-                        size: CGSize(width: cellSize, height: cellSize)
+        ZStack {
+            VStack(spacing: 0) {
+                // Navigation Bar
+                CustomNavigationBar(
+                    title: TextLiteral.Add.recordTitle,
+                    onBack: {
+                        viewModel.dismissView()
+                    },
+                    rightButton: .text(
+                        title: TextLiteral.Common.complete,
+                        isEnabled: viewModel.isCompleteEnabled
                     ) {
-                        viewModel.showCamera()
+                        viewModel.completeSelection()
                     }
-                    
-                    if viewModel.photos.isEmpty {
-                        // 스켈레톤 셀들
-                        ForEach(0..<40, id: \.self) { _ in
-                            SkeletonCell(size: CGSize(width: cellSize, height: cellSize))
+                )
+                
+                // Album Selector
+                Button {
+                    viewModel.showAlbumSheet()
+                } label: {
+                    HStack(spacing: 4) {
+                        Text(viewModel.selectedAlbumTitle)
+                            .font(.codive_body1_medium)
+                            .foregroundStyle(Color.Codive.grayscale1)
+                        
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 14))
+                            .foregroundStyle(Color.Codive.grayscale3)
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 16)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                
+                // Photo Grid
+                ScrollView {
+                    LazyVGrid(columns: columns, spacing: 3) {
+                        // 첫 번째 셀: 카메라
+                        CameraCell(
+                            size: CGSize(width: cellSize, height: cellSize)
+                        ) {
+                            viewModel.showCamera()
                         }
-                    } else {
-                        // 실제 사진들
-                        ForEach(viewModel.photos) { photo in
-                            PhotoGridCell(
-                                asset: photo.asset,
-                                isSelected: photo.isSelected,
-                                selectionOrder: photo.selectionOrder,
-                                size: CGSize(width: cellSize, height: cellSize),
-                                viewModel: viewModel
-                            )
-                            .onTapGesture {
-                                viewModel.togglePhotoSelection(photo)
+                        
+                        if viewModel.photos.isEmpty {
+                            // 스켈레톤 셀들
+                            ForEach(0..<40, id: \.self) { _ in
+                                SkeletonCell(size: CGSize(width: cellSize, height: cellSize))
+                            }
+                        } else {
+                            // 실제 사진들
+                            ForEach(viewModel.photos) { photo in
+                                PhotoGridCell(
+                                    asset: photo.asset,
+                                    isSelected: photo.isSelected,
+                                    selectionOrder: photo.selectionOrder,
+                                    size: CGSize(width: cellSize, height: cellSize),
+                                    viewModel: viewModel
+                                )
+                                .onTapGesture {
+                                    viewModel.togglePhotoSelection(photo)
+                                }
                             }
                         }
                     }
                 }
+            }
+            // 로딩 오버레이
+            if viewModel.isCompletingSelection {
+                LoadingView()
             }
         }
         .navigationBarHidden(true)

--- a/Codive/Features/Add/Presentation/View/RecordAddView.swift
+++ b/Codive/Features/Add/Presentation/View/RecordAddView.swift
@@ -66,17 +66,24 @@ struct RecordAddView: View {
                         viewModel.showCamera()
                     }
                     
-                    // 나머지 셀: 갤러리 사진들
-                    ForEach(viewModel.photos) { photo in
-                        PhotoGridCell(
-                            asset: photo.asset,
-                            isSelected: photo.isSelected,
-                            selectionOrder: photo.selectionOrder,
-                            size: CGSize(width: cellSize, height: cellSize),
-                            viewModel: viewModel
-                        )
-                        .onTapGesture {
-                            viewModel.togglePhotoSelection(photo)
+                    if viewModel.photos.isEmpty {
+                        // 스켈레톤 셀들
+                        ForEach(0..<40, id: \.self) { _ in
+                            SkeletonCell(size: CGSize(width: cellSize, height: cellSize))
+                        }
+                    } else {
+                        // 실제 사진들
+                        ForEach(viewModel.photos) { photo in
+                            PhotoGridCell(
+                                asset: photo.asset,
+                                isSelected: photo.isSelected,
+                                selectionOrder: photo.selectionOrder,
+                                size: CGSize(width: cellSize, height: cellSize),
+                                viewModel: viewModel
+                            )
+                            .onTapGesture {
+                                viewModel.togglePhotoSelection(photo)
+                            }
                         }
                     }
                 }
@@ -90,7 +97,7 @@ struct RecordAddView: View {
                 selectedAlbum: viewModel.selectedAlbum,
                 viewModel: viewModel
             ) { album in
-                viewModel.selectAlbum(album)
+                await viewModel.selectAlbum(album)
             }
             .presentationDetents([.medium, .large])
             .presentationDragIndicator(.hidden)

--- a/Codive/Features/Add/Presentation/View/RecordAddView.swift
+++ b/Codive/Features/Add/Presentation/View/RecordAddView.swift
@@ -117,8 +117,5 @@ struct RecordAddView: View {
         .task {
             await viewModel.requestAuthorization()
         }
-        .onAppear {
-            viewModel.resetSelection()
-        }
     }
 }

--- a/Codive/Features/Add/Presentation/ViewModel/PhotoEditViewModel.swift
+++ b/Codive/Features/Add/Presentation/ViewModel/PhotoEditViewModel.swift
@@ -59,6 +59,7 @@ final class PhotoEditViewModel: ObservableObject {
     func updateCroppedImage(_ image: UIImage) {
         guard selectedPhotos.indices.contains(currentIndex) else { return }
         selectedPhotos[currentIndex].croppedImage = image
+        objectWillChange.send()
         isEditingMode = false
     }
     

--- a/Codive/Features/Add/Presentation/ViewModel/PhotoEditViewModel.swift
+++ b/Codive/Features/Add/Presentation/ViewModel/PhotoEditViewModel.swift
@@ -59,7 +59,6 @@ final class PhotoEditViewModel: ObservableObject {
     func updateCroppedImage(_ image: UIImage) {
         guard selectedPhotos.indices.contains(currentIndex) else { return }
         selectedPhotos[currentIndex].croppedImage = image
-        objectWillChange.send()
         isEditingMode = false
     }
     

--- a/Codive/Features/Add/Presentation/ViewModel/RecordAddViewModel.swift
+++ b/Codive/Features/Add/Presentation/ViewModel/RecordAddViewModel.swift
@@ -169,11 +169,11 @@ final class RecordAddViewModel: ObservableObject {
                 }
             }
             
+            navigationRouter.navigate(to: .photoEdit(photos: selectedPhotoItems))
+                    
             // 처리 완료 후 리셋
             resetSelection()
-            
             isCompletingSelection = false
-            navigationRouter.navigate(to: .photoEdit(photos: selectedPhotoItems))
         }
     }
     

--- a/Codive/Features/Add/Presentation/ViewModel/RecordAddViewModel.swift
+++ b/Codive/Features/Add/Presentation/ViewModel/RecordAddViewModel.swift
@@ -21,8 +21,8 @@ final class RecordAddViewModel: ObservableObject {
     @Published var isAlbumSheetPresented = false
     @Published var isCameraPresented = false
     @Published var authorizationStatus: PHAuthorizationStatus = .notDetermined
-    @Published var isLoadingPhotos = false
-    
+    @Published var isCompletingSelection = false
+
     private let fetchPhotosUseCase: FetchPhotosUseCase
     private let processImageUseCase: ProcessImageUseCase
     let navigationRouter: NavigationRouter
@@ -144,6 +144,8 @@ final class RecordAddViewModel: ObservableObject {
     
     func completeSelection() {
         Task {
+            isCompletingSelection = true
+            
             var selectedPhotoItems: [SelectedPhoto] = []
             
             for (index, photo) in selectedPhotos.enumerated() {
@@ -163,9 +165,11 @@ final class RecordAddViewModel: ObservableObject {
                 }
             }
             
+            isCompletingSelection = false
             navigationRouter.navigate(to: .photoEdit(photos: selectedPhotoItems))
         }
     }
+    
     func resetSelection() {
         selectedPhotos.removeAll()
         for index in photos.indices {

--- a/Codive/Features/Add/Presentation/ViewModel/RecordAddViewModel.swift
+++ b/Codive/Features/Add/Presentation/ViewModel/RecordAddViewModel.swift
@@ -148,7 +148,10 @@ final class RecordAddViewModel: ObservableObject {
             
             var selectedPhotoItems: [SelectedPhoto] = []
             
-            for (index, photo) in selectedPhotos.enumerated() {
+            // 임시로 사진 순서 저장
+            let photosToProcess = selectedPhotos
+            
+            for (index, photo) in photosToProcess.enumerated() {
                 if let image = await fetchPhotosUseCase.loadThumbnail(
                     for: photo.asset,
                     size: PHImageManagerMaximumSize
@@ -164,6 +167,9 @@ final class RecordAddViewModel: ObservableObject {
                     selectedPhotoItems.append(selectedPhoto)
                 }
             }
+            
+            // 처리 완료 후 리셋
+            resetSelection()
             
             isCompletingSelection = false
             navigationRouter.navigate(to: .photoEdit(photos: selectedPhotoItems))

--- a/Codive/Features/Add/Presentation/ViewModel/RecordAddViewModel.swift
+++ b/Codive/Features/Add/Presentation/ViewModel/RecordAddViewModel.swift
@@ -150,11 +150,12 @@ final class RecordAddViewModel: ObservableObject {
             
             // 임시로 사진 순서 저장
             let photosToProcess = selectedPhotos
+            let targetSize = CGSize(width: 1200, height: 1200)
             
             for (index, photo) in photosToProcess.enumerated() {
                 if let image = await fetchPhotosUseCase.loadThumbnail(
                     for: photo.asset,
-                    size: PHImageManagerMaximumSize
+                    size: targetSize
                 ) {
                     let croppedImage = processImageUseCase.cropTo3_4Ratio(image)
                     

--- a/Codive/Features/Add/Presentation/ViewModel/RecordAddViewModel.swift
+++ b/Codive/Features/Add/Presentation/ViewModel/RecordAddViewModel.swift
@@ -57,29 +57,23 @@ final class RecordAddViewModel: ObservableObject {
         authorizationStatus = await fetchPhotosUseCase.requestAuthorization()
         
         if authorizationStatus == .authorized || authorizationStatus == .limited {
-            loadAlbums()
+            await loadAlbums()
         }
     }
-    
-    func loadAlbums() {
-        isLoadingPhotos = true
-        
-        let (fetchedAlbums, defaultAlbum) = fetchPhotosUseCase.fetchAlbumsWithDefault()
+
+    func loadAlbums() async {
+        let (fetchedAlbums, defaultAlbum) = await fetchPhotosUseCase.fetchAlbumsWithDefault()
         
         albums = fetchedAlbums
         
         if let defaultAlbum = defaultAlbum {
-            selectAlbum(defaultAlbum)
-        }
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            self.isLoadingPhotos = false
+            await selectAlbum(defaultAlbum)
         }
     }
     
-    func selectAlbum(_ album: PhotoAlbum) {
+    func selectAlbum(_ album: PhotoAlbum) async {
         selectedAlbum = album
-        photos = fetchPhotosUseCase.fetchPhotos(from: album)
+        photos = await fetchPhotosUseCase.fetchPhotos(from: album)
         isAlbumSheetPresented = false
     }
     
@@ -134,7 +128,7 @@ final class RecordAddViewModel: ObservableObject {
             // 선택 상태 초기화
             selectedPhotos.removeAll()
             // 저장 후 갤러리 새로고침
-            loadAlbums()
+            await loadAlbums()
         }
     }
     

--- a/Codive/Features/Add/Presentation/ViewModel/RecordAddViewModel.swift
+++ b/Codive/Features/Add/Presentation/ViewModel/RecordAddViewModel.swift
@@ -21,6 +21,7 @@ final class RecordAddViewModel: ObservableObject {
     @Published var isAlbumSheetPresented = false
     @Published var isCameraPresented = false
     @Published var authorizationStatus: PHAuthorizationStatus = .notDetermined
+    @Published var isLoadingPhotos = false
     
     private let fetchPhotosUseCase: FetchPhotosUseCase
     private let processImageUseCase: ProcessImageUseCase
@@ -61,12 +62,18 @@ final class RecordAddViewModel: ObservableObject {
     }
     
     func loadAlbums() {
+        isLoadingPhotos = true
+        
         let (fetchedAlbums, defaultAlbum) = fetchPhotosUseCase.fetchAlbumsWithDefault()
         
         albums = fetchedAlbums
         
         if let defaultAlbum = defaultAlbum {
             selectAlbum(defaultAlbum)
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            self.isLoadingPhotos = false
         }
     }
     

--- a/Codive/Shared/Presentation/Components/Alerts/LoadingView.swift
+++ b/Codive/Shared/Presentation/Components/Alerts/LoadingView.swift
@@ -11,10 +11,10 @@ struct LoadingView: View {
     
     var body: some View {
         ZStack {
-            Color.white
+            Color.black.opacity(0.3)
             
             ProgressView()
-                .progressViewStyle(CircularProgressViewStyle(tint: Color.Codive.main0))
+                .progressViewStyle(CircularProgressViewStyle(tint: Color.Codive.point2))
                 .scaleEffect(1.5)
         }
         .ignoresSafeArea()

--- a/Codive/Shared/Presentation/Components/Alerts/LoadingView.swift
+++ b/Codive/Shared/Presentation/Components/Alerts/LoadingView.swift
@@ -1,0 +1,22 @@
+//
+//  LoadingView.swift
+//  Codive
+//
+//  Created by 황상환 on 11/3/25.
+//
+
+import SwiftUI
+
+struct LoadingView: View {
+    
+    var body: some View {
+        ZStack {
+            Color.white
+            
+            ProgressView()
+                .progressViewStyle(CircularProgressViewStyle(tint: Color.Codive.main0))
+                .scaleEffect(1.5)
+        }
+        .ignoresSafeArea()
+    }
+}

--- a/Project.swift
+++ b/Project.swift
@@ -123,7 +123,7 @@ let project = Project(
                 .external(name: "Moya"),
                 
                 // 이미지 크롭
-                .external(name: "Mantis"),
+                .external(name: "SwiftyCrop"),
             ],
             settings: .settings(
                 base: [

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fd4104770e216640cf81c6e2eb619f77b730335b205d50fc963444b9d728f734",
+  "originHash" : "306c8b0a5b438619961ac50341bbf6216374f61a50ac7a0c9a300298070b8c51",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -17,15 +17,6 @@
       "state" : {
         "revision" : "f17e30773062d9df4c8e0e211da9ac22dfb2e5c1",
         "version" : "2.24.6"
-      }
-    },
-    {
-      "identity" : "mantis",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/guoyingtao/Mantis.git",
-      "state" : {
-        "revision" : "d471b02c6ab8c1432b612738b0f63eaff980df1c",
-        "version" : "2.27.0"
       }
     },
     {
@@ -53,6 +44,15 @@
       "state" : {
         "revision" : "5dd1907d64f0d36f158f61a466bab75067224893",
         "version" : "6.9.0"
+      }
+    },
+    {
+      "identity" : "swiftycrop",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/benedom/SwiftyCrop.git",
+      "state" : {
+        "revision" : "5caca6629d98d34988161dc474b27e5e8584de40",
+        "version" : "2.0.0"
       }
     }
   ],

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -18,6 +18,6 @@ let package = Package(
         // 카카오 SDK
         .package(url: "https://github.com/kakao/kakao-ios-sdk", from: "2.22.5"),
         .package(url: "https://github.com/Moya/Moya.git", from: "15.0.0"),
-        .package(url: "https://github.com/guoyingtao/Mantis.git", from: "2.27.0")
+        .package(url: "https://github.com/benedom/SwiftyCrop.git", from: "2.0.0")
     ]
 )


### PR DESCRIPTION
### 🔗 연결된 이슈
Resolved #17

✨ 주요 작업사항
> 이번 PR의 핵심 변경사항을 알려주세요!

**1. 비동기 데이터 처리 및 UI 응답성 향상**

- `FetchPhotosUseCase`, `RecordAddViewModel` 및 관련 뷰에서 `async/await`를 사용하도록 리팩토링하여, 앨범 및 사진 조회 시의 응답성과 안정성을 개선했습니다.
- UI 컴포넌트 내의 앨범 및 사진 선택 콜백을 비동기로 업데이트하여, 데이터가 준비된 후에 UI가 업데이트되도록 보장합니다.

**2. 로딩 피드백 개선**

- 새로운 `LoadingView` 컴포넌트를 추가하고 `RecordAddView`에 통합하여, 사진 선택 완료 시 로딩 오버레이를 표시함으로써 사용자에게 명확한 피드백을 제공합니다.
- `SkeletonCell` 컴포넌트를 도입하여 사진 로딩 중 플레이스홀더 UI(스켈레톤 셀)를 표시하여, 체감 성능과 사용자 경험을 향상시켰습니다.

**3. 이미지 크롭 기능 현대화**

- 기존 Mantis 크롭 라이브러리를 SwiftyCrop으로 교체했습니다.
- `ImageCropView`가 새 라이브러리를 사용하도록 업데이트하고 크롭 워크플로우를 단순화하여, 유지보수성 및 사용자 경험을 개선했습니다.

**4. 사진 편집 워크플로우 개선**

- `PhotoEditView`에서 선택된 사진 인덱스가 정확히 업데이트되도록 수정했습니다.
- 크롭 또는 취소 동작 후 편집 모드가 올바르게 종료되도록 편집 흐름을 개선했습니다.

**5. 의존성 및 프로젝트 설정**

- Mantis를 제거하고 SwiftyCrop을 추가하도록 프로젝트 의존성 및 구성 파일을 업데이트하여, 새 라이브러리가 올바르게 통합되도록 했습니다.


### 📸 스크린샷 / 동영상
> 구현한 화면의 크기를 `img width="250"`로 설정해서 첨부해주세요!

![Simulator Screen Recording - iPhone Air - 2025-11-03 at 22 37 44](https://github.com/user-attachments/assets/99125277-c629-4d89-86c8-24fe87f8e44b)

### 🔍 리뷰어에게 (선택)
> 코드 리뷰 시 특별히 확인했으면 하는 부분이나, 의견을 묻고 싶은 내용을 적어주세요!
- 사진 편집 라이브러리로 Mantis나 TOCropViewController 를 사용해보려했으나, SwiftUI와 호환이 제대로 되지 않아 SwiftyCrop으로 변경했습니다. 
- 기록추가 뷰 -> 사진 편집 뷰 & 사진 크롭 으로 이어지는 플로우에서 사용성을 해칠 수 있는 문제들을 해결했습니다.
- 공통컴포넌트에 임시로 LoadingView를 생성하여 사용했는데, 로딩 관련 해서 디자인 팀에게 컨펌을 넣어둔 상태라 UI가 변경될 수 있습니다. 

