### PR TITLE
[#65] UX 1차 기능 추가 및 수정

### DIFF
--- a/Codive/Features/Home/Presentation/Component/CodiClothView.swift
+++ b/Codive/Features/Home/Presentation/Component/CodiClothView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ClothCardView: View {
     let item: HomeClothEntity
     let width: CGFloat
+    @State private var reloadKey = UUID()
     
     var body: some View {
         VStack {
@@ -26,20 +27,51 @@ struct ClothCardView: View {
                     .frame(height: 124)
                     .frame(width: 124)
                     .overlay {
-                        if let url = URL(string: item.imageUrl), !item.imageUrl.isEmpty {
-                            AsyncImage(url: url) { phase in
+                        if let url = URL(string: item.imageUrl),
+                           !item.imageUrl.isEmpty {
+
+                            AsyncImage(url: url, transaction: Transaction(animation: .easeInOut)) { phase in
                                 switch phase {
                                 case .empty:
-                                    ProgressView()
+                                    ZStack {
+                                        RoundedRectangle(cornerRadius: 15)
+                                            .fill(Color.Codive.grayscale7)
+                                        ProgressView()
+                                    }
+
                                 case .success(let image):
-                                    image.resizable().scaledToFit()
-                                case .failure:
-                                    Image(systemName: "exclamationmark.triangle")
-                                        .foregroundColor(.gray)
+                                    image
+                                        .resizable()
+                                        .scaledToFit()
+                                        .transition(.opacity)
+
+                                case .failure(let error):
+                                    if let urlError = error as? URLError, urlError.code == .cancelled {
+                                        // Retry automatically on next runloop
+                                        Color.clear
+                                            .onAppear {
+                                                DispatchQueue.main.async {
+                                                    reloadKey = UUID()
+                                                }
+                                            }
+                                    } else {
+                                        ZStack {
+                                            RoundedRectangle(cornerRadius: 15)
+                                                .fill(Color.Codive.grayscale7)
+                                            Image(systemName: "exclamationmark.triangle")
+                                                .foregroundColor(.gray)
+                                        }
+                                        .onAppear {
+                                            print("Image load failed:", item.imageUrl)
+                                            print("Error:", error.localizedDescription)
+                                        }
+                                    }
+
                                 @unknown default:
                                     EmptyView()
                                 }
                             }
+                            .id(reloadKey)
                             .clipShape(RoundedRectangle(cornerRadius: 15))
                         } else {
                             Image(item.imageUrl)
@@ -177,6 +209,11 @@ struct CodiClothCarouselView: View {
                 .onAppear {
                     proxy.scrollTo(currentIndex, anchor: .center)
                 }
+                .onChange(of: items.count) { _ in
+                    withAnimation(.spring()) {
+                        proxy.scrollTo(currentIndex, anchor: .center)
+                    }
+                }
             }
             .clipShape(RoundedRectangle(cornerRadius: 20))
             .background {
@@ -196,21 +233,18 @@ struct CodiClothView: View {
     let spacing: CGFloat = 12
     let activeScale: CGFloat = 1.0
     let inactiveScale: CGFloat = 0.85
-    let selectedIndex: Int
-    var onIndexChanged: ((Int) -> Void)?
+    @Binding var currentIndex: Int
     
-    @State private var currentIndex: Int
-    
-    init(title: String, items: [HomeClothEntity], selectedIndex: Int = 0, isEmptyState: Bool, onIndexChanged: ((Int) -> Void)? = nil) {
+    init(
+        title: String,
+        items: [HomeClothEntity],
+        isEmptyState: Bool,
+        currentIndex: Binding<Int>
+    ) {
         self.title = title
         self.items = items
         self.isEmptyState = isEmptyState
-        self.selectedIndex = selectedIndex
-        self.onIndexChanged = onIndexChanged
-        
-        // 초기값 설정: 비어있으면 1(중앙), 아니면 전달받은 selectedIndex 사용
-        let initialIndex = isEmptyState ? 1 : selectedIndex
-        _currentIndex = State(initialValue: initialIndex)
+        self._currentIndex = currentIndex
     }
     
     var body: some View {
@@ -224,21 +258,6 @@ struct CodiClothView: View {
                     inactiveScale: inactiveScale,
                     isEmptyState: isEmptyState
                 )
-                .onChange(of: currentIndex) { newValue in
-                    onIndexChanged?(newValue)
-                }
-                // 중요: 부모가 준 selectedIndex가 바뀌면(수정 버튼 클릭 시) 내부 currentIndex도 동기화
-                .onChange(of: selectedIndex) { newValue in
-                    withAnimation(.spring()) {
-                        self.currentIndex = newValue
-                    }
-                }
-                .onAppear {
-                    // 비어있는 상태가 아닐 때만 0번(또는 초기값)을 전달
-                    if !isEmptyState {
-                        onIndexChanged?(currentIndex)
-                    }
-                }
                 
                 // 카테고리 태그
                 Text(title)

--- a/Codive/Features/Home/Presentation/Component/DraggableImageView.swift
+++ b/Codive/Features/Home/Presentation/Component/DraggableImageView.swift
@@ -33,6 +33,7 @@ struct DraggableImageView<T: DraggableImageProtocol>: View {
                             .resizable()
                             .scaledToFit()
                             .frame(width: 180, height: 180)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
                     }
                 )
             }

--- a/Codive/Features/Home/Presentation/Component/SelectableClothItem.swift
+++ b/Codive/Features/Home/Presentation/Component/SelectableClothItem.swift
@@ -15,19 +15,20 @@ struct SelectableClothItem: View {
         ZStack {
             AsyncImage(url: URL(string: entity.imageUrl)) { phase in
                 if let image = phase.image {
-                    image.resizable().scaledToFill()
+                    image
+                        .resizable()
+                        .scaledToFill()
                 } else {
                     Color.gray.opacity(0.2)
                 }
             }
-            .frame(width: 68, height: 68)
-            .clipped()
-            .cornerRadius(8)
+            .frame(width: 72, height: 72)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
         }
-        .frame(width: 72, height: 72)
         .overlay {
             RoundedRectangle(cornerRadius: 8)
-                .stroke(isSelected ? Color.blue : Color.clear, lineWidth: 2)
+                .inset(by: 1)
+                .stroke(isSelected ? Color.Codive.main3 : Color.Codive.grayscale6, lineWidth: 1.5)
         }
         .onTapGesture {
             isSelected.toggle()

--- a/Codive/Features/Home/Presentation/View/HomeHasCodiView.swift
+++ b/Codive/Features/Home/Presentation/View/HomeHasCodiView.swift
@@ -42,6 +42,13 @@ struct HomeHasCodiView: View {
                 
                 bottomBanner
             }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                // 2. 메뉴가 열려있을 때 바탕을 누르면 닫기
+                if viewModel.isOverflowMenuExpanded {
+                    viewModel.closeOverflowMenu()
+                }
+            }
             
             overflowMenu
         }
@@ -73,7 +80,11 @@ private extension HomeHasCodiView {
                 { viewModel.selectEditCodi() },
                 { viewModel.addLookbook() },
                 { viewModel.sharedCodi() }
-            ]
+            ],
+            isExpanded: viewModel.isOverflowMenuExpanded,
+            showButton: true,
+            onToggle: viewModel.toggleOverflowMenu,
+            onClose: viewModel.closeOverflowMenu
         )
         .zIndex(9999)
     }

--- a/Codive/Features/Home/Presentation/View/HomeNoCodiView.swift
+++ b/Codive/Features/Home/Presentation/View/HomeNoCodiView.swift
@@ -69,16 +69,17 @@ private extension HomeNoCodiView {
             VStack(spacing: 16) {
                 ForEach(viewModel.activeCategories, id: \.id) { category in
                     let items: [HomeClothEntity] = viewModel.clothItemsByCategory[category.id] ?? []
-                    let selectedIdx: Int = viewModel.selectedIndicesByCategory[category.id] ?? 0
+                    let selectedIdx = Binding(
+                        get: { viewModel.selectedIndicesByCategory[category.id] ?? 0 },
+                        set: { viewModel.selectedIndicesByCategory[category.id] = $0 }
+                    )
                     
                     CodiClothView(
                         title: category.title,
                         items: items,
-                        selectedIndex: selectedIdx,
-                        isEmptyState: items.isEmpty
-                    ) { newIndex in
-                        viewModel.updateSelectedIndex(for: category.id, index: newIndex)
-                    }
+                        isEmptyState: items.isEmpty,
+                        currentIndex: selectedIdx
+                    )
                     .id(category.id)
                     .background(Color.white)
                     .cornerRadius(15)

--- a/Codive/Features/Home/Presentation/ViewModel/CodiBoardViewModel.swift
+++ b/Codive/Features/Home/Presentation/ViewModel/CodiBoardViewModel.swift
@@ -87,6 +87,7 @@ final class CodiBoardViewModel: ObservableObject {
             }
                 .frame(width: actualSize, height: actualSize)
                 .clipShape(RoundedRectangle(cornerRadius: 15))
+                .background(Color.white)
             
             let renderer = ImageRenderer(content: captureView)
             renderer.scale = UIScreen.main.scale

--- a/Codive/Features/Home/Presentation/ViewModel/HomeViewModel+.swift
+++ b/Codive/Features/Home/Presentation/ViewModel/HomeViewModel+.swift
@@ -10,8 +10,17 @@ import Photos
 
 // MARK: - LookBook Actions
 extension HomeViewModel {
+    func toggleOverflowMenu() {
+        isOverflowMenuExpanded.toggle()
+    }
+    
+    func closeOverflowMenu() {
+        isOverflowMenuExpanded = false
+    }
+    
     /// 오늘의 코디 수정
     func selectEditCodi() {
+        isOverflowMenuExpanded = false
         
         // 2. 수정 모드 플래그 활성화 및 화면 전환
         self.isEditingExistingCodi = true
@@ -48,6 +57,7 @@ extension HomeViewModel {
     }
     
     func sharedCodi() {
+        isOverflowMenuExpanded = false
         // 1. 저장할 이미지 URL 확인
         guard let imageUrlString = todayCodiPreview?.imageUrl,
               let url = URL(string: imageUrlString) else {
@@ -91,6 +101,8 @@ extension HomeViewModel {
     }
     /// 내 룩북 리스트를 불러와 바텀시트를 표시
     func addLookbook() {
+        isOverflowMenuExpanded = false
+        
         Task {
             do {
                 let (content, _) = try await addToLookBookUseCase.fetchLookBookList(

--- a/Codive/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/Codive/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -27,6 +27,7 @@ final class HomeViewModel: ObservableObject {
     @Published var capturedImageURL: String?
     
     @Published var isEditingExistingCodi: Bool = false
+    @Published var isOverflowMenuExpanded: Bool = false
     
     // MARK: - Properties (Data)
     

--- a/Codive/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/Codive/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -251,6 +251,7 @@ extension HomeViewModel {
             
             let captureView = CodiCompositeView(clothes: items, loadedImages: loadedImages)
                 .frame(width: 260, height: 260)
+                .background(Color.white)
             
             let renderer = ImageRenderer(content: captureView)
             renderer.scale = UIScreen.main.scale
@@ -381,6 +382,7 @@ extension HomeViewModel {
     private func captureCompletedCodiImage() -> UIImage {
         let view = CodiCompositeView(clothes: selectedCodiClothes)
             .frame(width: 260, height: 260)
+            .background(Color.white)
         
         let controller = UIHostingController(rootView: view)
         let uiView = controller.view!

--- a/Codive/Features/Home/Presentation/ViewModel/HomeViewModel.swift
+++ b/Codive/Features/Home/Presentation/ViewModel/HomeViewModel.swift
@@ -141,8 +141,8 @@ extension HomeViewModel {
 
 extension HomeViewModel {
     func loadRecommendCategoryClothList(seasons: Set<Season>) async {
-        self.activeCategories = []
-        self.clothItemsByCategory = [:]
+//        self.activeCategories = []
+//        self.clothItemsByCategory = [:]
         
         let allCategories = categoryUseCase.loadCategories()
         let filteredCategories = allCategories.filter { $0.itemCount > 0 }
@@ -159,7 +159,9 @@ extension HomeViewModel {
                     categoryId: Int64(category.id),
                     season: seasons // 전달받은 seasons 사용
                 )
-                resultMap[category.id] = result.content
+                resultMap[category.id] = result.content.sorted {
+                    $0.clothId < $1.clothId   // 또는 createdAt 기준
+                }
             } catch {
                 print("Failed to load items for category \(category.id): \(error)")
                 resultMap[category.id] = []

--- a/Codive/Features/LookBook/Presentation/View/CodiDetailView.swift
+++ b/Codive/Features/LookBook/Presentation/View/CodiDetailView.swift
@@ -34,6 +34,12 @@ struct CodiDetailView: View {
                         infoSection
                     }
                 }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    if viewModel.isOverflowMenuExpanded {
+                        viewModel.closeOverflowMenu()
+                    }
+                }
             }
         }
         .navigationBarHidden(true)
@@ -60,7 +66,10 @@ private extension CodiDetailView {
                 menuActions: [
                     { viewModel.navigateToEditCodi() },
                     { viewModel.requestDelete() }
-                ]
+                ],
+                isExpanded: viewModel.isOverflowMenuExpanded,
+                onToggle: viewModel.toggleOverflowMenu,
+                onClose: viewModel.closeOverflowMenu
             )
         )
         .zIndex(10)

--- a/Codive/Features/LookBook/Presentation/View/LookBookView.swift
+++ b/Codive/Features/LookBook/Presentation/View/LookBookView.swift
@@ -24,6 +24,12 @@ struct LookBookView: View {
     var body: some View {
         ZStack {
             mainLayout
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    if viewModel.isOverflowMenuExpanded {
+                        viewModel.closeOverflowMenu()
+                    }
+                }
             addLookBookDialogOverlay
             
             if viewModel.isLoading {
@@ -85,7 +91,10 @@ struct LookBookView: View {
                 menuActions: [
                     viewModel.toggleAddDialog,
                     viewModel.handleDeleteAction
-                ]
+                ],
+                isExpanded: viewModel.isOverflowMenuExpanded,
+                onToggle: viewModel.toggleOverflowMenu,
+                onClose: viewModel.closeOverflowMenu
             )
         )
         .zIndex(10)

--- a/Codive/Features/LookBook/Presentation/View/SpecificLookBookView.swift
+++ b/Codive/Features/LookBook/Presentation/View/SpecificLookBookView.swift
@@ -42,7 +42,10 @@ struct SpecificLookBookView: View {
                         menuActions: [
                             { viewModel.navigateToAddCodi() },
                             { viewModel.handleEditAction() }
-                        ]
+                        ],
+                        isExpanded: viewModel.isOverflowMenuExpanded,
+                        onToggle: viewModel.toggleOverflowMenu,
+                        onClose: viewModel.closeOverflowMenu
                     )
                 )
                 .zIndex(10)
@@ -83,6 +86,12 @@ struct SpecificLookBookView: View {
                     }
                     .padding(.horizontal, 16)
                     .padding(.top, 16)
+                }
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    if viewModel.isOverflowMenuExpanded {
+                        viewModel.closeOverflowMenu()
+                    }
                 }
                 .onAppear {
                     if viewModel.specificLookBookCodiList.isEmpty {

--- a/Codive/Features/LookBook/Presentation/ViewModel/CodiDetailViewModel.swift
+++ b/Codive/Features/LookBook/Presentation/ViewModel/CodiDetailViewModel.swift
@@ -16,6 +16,7 @@ final class CodiDetailViewModel: ObservableObject {
     @Published var showClothSelector: Bool = false
     @Published var selectedIndex: Int?
     @Published var showDeleteAlert: Bool = false
+    @Published var isOverflowMenuExpanded: Bool = false
     
     private let navigationRouter: NavigationRouter
     private let codiUseCase: CodiUseCase
@@ -107,11 +108,20 @@ extension CodiDetailViewModel {
 }
 
 extension CodiDetailViewModel {
+    func toggleOverflowMenu() {
+        isOverflowMenuExpanded.toggle()
+    }
+    
+    func closeOverflowMenu() {
+        isOverflowMenuExpanded = false
+    }
+    
     func handleBackTap() {
         navigationRouter.navigateBack()
     }
     
     func navigateToEditCodi() {
+        isOverflowMenuExpanded = false
         guard let preview = coordinatePreview else { return }
         
         let payloads: [Payloads] = coordinateDetails.map { detail in
@@ -142,6 +152,7 @@ extension CodiDetailViewModel {
     }
     
     func requestDelete() {
+        isOverflowMenuExpanded = false
         showDeleteAlert = true
     }
     

--- a/Codive/Features/LookBook/Presentation/ViewModel/LookBookViewModel.swift
+++ b/Codive/Features/LookBook/Presentation/ViewModel/LookBookViewModel.swift
@@ -27,6 +27,7 @@ final class LookBookViewModel: ObservableObject {
     // MARK: - Published State (Editing)
     
     @Published var isEditing: Bool = false
+    @Published var isOverflowMenuExpanded: Bool = false
     @Published var selectedLookBookId: Int64?
     
     // MARK: - Published State (Dialog / Alert)
@@ -99,6 +100,7 @@ final class LookBookViewModel: ObservableObject {
     
     // MARK: - 룩북 삭제 동작
     func handleDeleteAction() {
+        isOverflowMenuExpanded = false
         toggleDeleteMode()
     }
     
@@ -149,6 +151,7 @@ final class LookBookViewModel: ObservableObject {
     }
     
     func toggleAddDialog() {
+        isOverflowMenuExpanded = false
         isShowingAddDialog.toggle()
     }
     
@@ -186,6 +189,14 @@ final class LookBookViewModel: ObservableObject {
             }
             isLoading = false
         }
+    }
+    
+    func toggleOverflowMenu() {
+        isOverflowMenuExpanded.toggle()
+    }
+    
+    func closeOverflowMenu() {
+        isOverflowMenuExpanded = false
     }
     
     // MARK: - Navigation

--- a/Codive/Features/LookBook/Presentation/ViewModel/SpecificLookBookViewModel.swift
+++ b/Codive/Features/LookBook/Presentation/ViewModel/SpecificLookBookViewModel.swift
@@ -12,6 +12,8 @@ final class SpecificLookBookViewModel: ObservableObject {
     private let navigationRouter: NavigationRouter
     private let specificLookBookUseCase: SpecificLookBookUseCase
     
+    @Published var isOverflowMenuExpanded: Bool = false
+    
     private let lookbookId: Int64
     @Published var name: String
     @Published var isEditingTitle = false
@@ -109,6 +111,7 @@ final class SpecificLookBookViewModel: ObservableObject {
     
     // MARK: - 코디 편집 모드 전환
     func handleEditAction() {
+        isOverflowMenuExpanded = false
         isEditing = true
     }
     
@@ -201,7 +204,16 @@ final class SpecificLookBookViewModel: ObservableObject {
         isEditingTitle = false
     }
     
+    func toggleOverflowMenu() {
+        isOverflowMenuExpanded.toggle()
+    }
+    
+    func closeOverflowMenu() {
+        isOverflowMenuExpanded = false
+    }
+    
     func navigateToAddCodi() {
+        isOverflowMenuExpanded = false
         navigationRouter.navigate(to: .addCodi(lookBookId: lookbookId))
     }
     

--- a/Codive/Shared/DesignSystem/Buttons/CustomOverflowMenu.swift
+++ b/Codive/Shared/DesignSystem/Buttons/CustomOverflowMenu.swift
@@ -138,7 +138,7 @@ private extension CustomOverflowMenu {
             .clipShape(RoundedRectangle(cornerRadius: 10))
             .shadow(color: .gray.opacity(0.2), radius: 10, x: 0, y: 2)
             .fixedSize(horizontal: true, vertical: false)
-            .offset(x: -15, y: 0)
+            .offset(x: -20, y: 40)
             .transition(.scale(scale: 0.8, anchor: .topTrailing).combined(with: .opacity))
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Codive/Shared/DesignSystem/Navigation/CustomNavigationBar.swift
+++ b/Codive/Shared/DesignSystem/Navigation/CustomNavigationBar.swift
@@ -11,7 +11,7 @@ import SwiftUI
 enum NavigationBarRightButton {
     case none
     case text(title: String, isEnabled: Bool, action: () -> Void)
-    case overflow(menuType: MenuType, menuActions: [() -> Void])
+    case overflow(menuType: MenuType, menuActions: [() -> Void], isExpanded: Bool = false, onToggle: (() -> Void)? = nil, onClose: (() -> Void)? = nil)
     case icon(imageName: String, isSystemIcon: Bool = true, isEnabled: Bool, action: () -> Void)
     case menu(imageName: String, isSystemIcon: Bool = true, isEnabled: Bool, action: () -> Void)
 }
@@ -131,8 +131,15 @@ struct CustomNavigationBar: View {
             }
             .disabled(!isEnabled)
             
-        case .overflow(let menuType, let menuActions):
-            CustomOverflowMenu(menuType: menuType, menuActions: menuActions)
+        case .overflow(let menuType, let menuActions, let isExpanded, let onToggle, let onClose):
+            CustomOverflowMenu(
+                menuType: menuType,
+                menuActions: menuActions,
+                isExpanded: isExpanded,
+                showButton: true,
+                onToggle: onToggle,
+                onClose: onClose
+            )
         }
     }
     

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -16,7 +16,7 @@
       "location" : "https://github.com/Clokey-dev/CodiveAPI",
       "state" : {
         "branch" : "main",
-        "revision" : "7ab86bbb84009fc727db58dd8661381d9988b665"
+        "revision" : "74c664bb27e05add7e3abe634a45029d5505ef88"
       }
     },
     {


### PR DESCRIPTION
### 🔗 연결된 이슈
Resolved #65 

✨ 주요 작업사항
> 이번 PR의 핵심 변경사항을 알려주세요!

Home 및 LookBook 기능 전반에 걸쳐 여러 UI 및 상호작용 개선을 도입했으며, 특히 메뉴 처리 개선, 이미지 로딩 안정성 강화, 그리고 캐러셀 컴포넌트의 상태 관리 리팩토링에 중점을 두었습니다. 가장 주요한 변경 사항은 일관된 오버플로우 메뉴 패턴 구현, 이미지 로딩 및 에러 처리 개선, 그리고 캐러셀 인덱스 상태 관리 구조 개선입니다.

**오버플로우 메뉴 개선:**
- HomeViewModel 및 관련 ViewModel에 isOverflowMenuExpanded 상태와 toggleOverflowMenu, closeOverflowMenu 액션을 추가하여 여러 화면에서 오버플로우 메뉴를 일관되게 제어할 수 있도록 했습니다.
- 메뉴 바깥 영역을 탭하면 메뉴가 닫히도록 동작을 추가했습니다.
- 메뉴 컴포넌트는 확장 상태와 콜백을 props로 전달받도록 구조를 개선했습니다.

**이미지 로딩 및 UI 개선:**
- ClothCardView의 AsyncImage 처리 방식을 개선하여 더 나은 로딩 상태 표시, 에러 발생 시 피드백 제공, 취소(cancellation) 시 자동 재시도, 이미지 컨테이너에 부드러운 전환 효과 및 배경 추가를 적용했습니다. 
- 여러 컴포넌트에서 이미지 클리핑 및 배경 처리를 RoundedRectangle로 통일하여 UI 일관성을 강화했습니다.

**캐러셀 및 상태 관리 리팩토링:**

- CodiClothView에서 내부 상태 및 콜백 기반 구조를 제거하고, currentIndex를 @Binding으로 변경하여 부모-자식 간 상태 동기화를 단순화했습니다.
- 이에 따라 부모 View에서도 사용 방식을 업데이트했습니다.
- 아이템 개수가 변경될 때 캐러셀의 스크롤 위치를 유지하는 로직을 추가하여 더 부드러운 사용자 경험을 제공하도록 개선했습니다.

**데이터 로딩 및 정렬 개선:**
- 카테고리별 옷 아이템 로딩 시 clothId 기준으로 정렬하여 항상 일관된 순서로 표시되도록 변경했습니다.

**기타 수정 사항:**
- 비동기 로딩 시 카테고리 및 아이템 리스트를 초기화하던 일부 코드를 주석 처리하여, reload 시에도 기존 상태가 유지되도록 조정했습니다.

### 📸 스크린샷 / 동영상
> 구현한 화면의 크기를 `img width="250"`로 설정해서 첨부해주세요!


### 🔍 리뷰어에게 (선택)
> 코드 리뷰 시 특별히 확인했으면 하는 부분이나, 의견을 묻고 싶은 내용을 적어주세요!
-
